### PR TITLE
refactor: CodeRabbitレビュー指摘事項を修正

### DIFF
--- a/include/builtin.h
+++ b/include/builtin.h
@@ -19,6 +19,7 @@
 typedef struct s_shell	t_shell;
 
 int						is_builtin(char *cmd);
+int						is_builtin_cmd(char **argv);
 int						exec_builtin(char **argv, t_shell *shell);
 
 int						builtin_echo(char **argv);

--- a/src/builtins/builtins.c
+++ b/src/builtins/builtins.c
@@ -39,6 +39,15 @@ int	is_builtin(char *cmd)
 	return (0);
 }
 
+int	is_builtin_cmd(char **argv)
+{
+	if (!is_builtin(argv[0]))
+		return (0);
+	if (ft_strncmp(argv[0], "env", 4) == 0 && argv[1])
+		return (0);
+	return (1);
+}
+
 static int	exec_builtin_sub(char **argv, t_shell *shell)
 {
 	if (str_equal(argv[0], "export"))
@@ -52,8 +61,10 @@ static int	exec_builtin_sub(char **argv, t_shell *shell)
 	return (1);
 }
 
-static int	exec_builtin_cmd(char **argv, t_shell *shell)
+int	exec_builtin(char **argv, t_shell *shell)
 {
+	if (!argv || !argv[0])
+		return (1);
 	if (str_equal(argv[0], "echo"))
 		return (builtin_echo(argv));
 	if (str_equal(argv[0], "cd"))
@@ -61,11 +72,4 @@ static int	exec_builtin_cmd(char **argv, t_shell *shell)
 	if (str_equal(argv[0], "pwd"))
 		return (builtin_pwd());
 	return (exec_builtin_sub(argv, shell));
-}
-
-int	exec_builtin(char **argv, t_shell *shell)
-{
-	if (!argv || !argv[0])
-		return (1);
-	return (exec_builtin_cmd(argv, shell));
 }

--- a/src/builtins/exit.c
+++ b/src/builtins/exit.c
@@ -86,7 +86,8 @@ int	builtin_exit(char **argv, t_shell *shell)
 	int	exit_code;
 	int	err;
 
-	ft_putendl_fd("exit", STDERR_FILENO);
+	if (isatty(STDIN_FILENO))
+		ft_putendl_fd("exit", STDERR_FILENO);
 	argc = count_args(argv);
 	if (argc == 1)
 		return (request_exit(shell, shell->exit_status));

--- a/src/executor/execute_cmd.c
+++ b/src/executor/execute_cmd.c
@@ -75,15 +75,11 @@ int	execute_simple_command(t_cmd *cmd, t_shell *shell)
 {
 	pid_t	pid;
 	int		status;
-	int		builtin;
 
 	expand_command(cmd, shell);
 	if (!cmd->argv || !cmd->argv[0])
 		return (0);
-	builtin = is_builtin(cmd->argv[0]);
-	if (builtin && ft_strncmp(cmd->argv[0], "env", 4) == 0 && cmd->argv[1])
-		builtin = 0;
-	if (builtin)
+	if (is_builtin_cmd(cmd->argv))
 		return (exec_builtin_with_redir(cmd, shell));
 	setup_signals_ignore();
 	pid = fork();

--- a/src/pipeline/pipe_utils.c
+++ b/src/pipeline/pipe_utils.c
@@ -66,12 +66,8 @@ static void	exec_cmd_or_builtin(t_cmd *cmd, t_shell *shell)
 {
 	char	*path;
 	char	**envp;
-	int		builtin;
 
-	builtin = is_builtin(cmd->argv[0]);
-	if (builtin && ft_strncmp(cmd->argv[0], "env", 4) == 0 && cmd->argv[1])
-		builtin = 0;
-	if (builtin)
+	if (is_builtin_cmd(cmd->argv))
 		exit(exec_builtin(cmd->argv, shell));
 	path = find_command(cmd->argv[0], shell);
 	if (!path)
@@ -83,6 +79,9 @@ static void	exec_cmd_or_builtin(t_cmd *cmd, t_shell *shell)
 	}
 	envp = env_list_to_envp(shell->env_list);
 	execve(path, cmd->argv, envp);
+	ft_putstr_fd("minishell: ", STDERR_FILENO);
+	ft_putstr_fd(cmd->argv[0], STDERR_FILENO);
+	ft_putendl_fd(": Permission denied", STDERR_FILENO);
 	exit(ERR_PERM);
 }
 


### PR DESCRIPTION
## Summary
- `is_builtin_cmd()` ヘルパーを抽出し、`execute_cmd.c` と `pipe_utils.c` の env 引数チェックの重複を解消
- `pipe_utils.c` の `execve` 失敗時に "Permission denied" エラーメッセージを追加（`exec_external` と統一）
- `exit` ビルトインの "exit" メッセージを `isatty(STDIN_FILENO)` で制御し、パイプ子プロセスでの不要な出力を抑制

## Test plan
- [ ] `exit 42` → インタラクティブ時に "exit" が表示され、ステータス 42 で終了
- [ ] `echo test | exit` → パイプ内で "exit" メッセージが出力されないことを確認
- [ ] `env PATH=/usr/bin ls` → 外部コマンドとして正常に実行
- [ ] `env` 単体 → ビルトインとして環境変数一覧を表示

## 関連する Issue
- CodeRabbit レビュー指摘 (PR #13): Nitpick 3, 4 および Actionable comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)