### PR TITLE
fix: NULLガード追加と負数exit引数の符号問題を修正

### DIFF
--- a/src/builtins/builtins.c
+++ b/src/builtins/builtins.c
@@ -41,6 +41,8 @@ int	is_builtin(char *cmd)
 
 int	is_builtin_cmd(char **argv)
 {
+	if (!argv || !argv[0])
+		return (0);
 	if (!is_builtin(argv[0]))
 		return (0);
 	if (ft_strncmp(argv[0], "env", 4) == 0 && argv[1])

--- a/src/builtins/exit.c
+++ b/src/builtins/exit.c
@@ -91,7 +91,7 @@ int	builtin_exit(char **argv, t_shell *shell)
 	argc = count_args(argv);
 	if (argc == 1)
 		return (request_exit(shell, shell->exit_status));
-	exit_code = (int)(ft_atoll(argv[1], &err) % 256);
+	exit_code = (int)(ft_atoll(argv[1], &err) & 0xFF);
 	if (!is_numeric(argv[1]) || err)
 	{
 		ft_putstr_fd("minishell: exit: ", STDERR_FILENO);

--- a/src/pipeline/pipe_utils.c
+++ b/src/pipeline/pipe_utils.c
@@ -92,5 +92,7 @@ void	exec_pipe_child(t_cmd *cmd, t_shell *shell, int in_fd, int out_fd)
 	if (setup_redirections(cmd->redirects) == -1)
 		exit(1);
 	expand_command(cmd, shell);
+	if (!cmd->argv || !cmd->argv[0])
+		exit(0);
 	exec_cmd_or_builtin(cmd, shell);
 }


### PR DESCRIPTION
## Summary
- `is_builtin_cmd()` に `!argv || !argv[0]` の NULL ガードを追加し、パイプライン内で変数展開が空コマンドになった場合のクラッシュを防止
- `exec_pipe_child()` に argv NULL チェックを追加（`execute_cmd.c` 側と同等のガード）
- `exit` 引数の `% 256` を `& 0xFF` に変更し、負数入力で正しい終了コードを返すよう修正（`exit -1` → 255）

## Test plan
- [ ] `exit -1` → 終了ステータスが 255 になることを確認
- [ ] `exit -2` → 終了ステータスが 254 になることを確認
- [ ] `exit 42` → 従来通りステータス 42 で終了
- [ ] パイプライン内で空コマンドが展開された場合にクラッシュしないことを確認

## 関連する Issue
- Closes #18 (is_builtin_cmd NULL ガード欠如)
- Closes #19 (負数 exit 引数の符号問題)

🤖 Generated with [Claude Code](https://claude.com/claude-code)